### PR TITLE
Remove sequelize imports in models

### DIFF
--- a/server/database/models/Experiment.ts
+++ b/server/database/models/Experiment.ts
@@ -1,5 +1,4 @@
 import { DataTypes, Model } from "sequelize"
-import sequelize from "../utils/sequelize"
 
 const experimentStatusEnum = DataTypes.ENUM("Draft", "Submitted", "Accepted")
 class Experiment extends Model {}

--- a/server/database/models/ExperimentAttributes.ts
+++ b/server/database/models/ExperimentAttributes.ts
@@ -1,5 +1,4 @@
 import { DataTypes, Model } from "sequelize"
-import sequelize from "../utils/sequelize"
 
 class ExperimentAttributes extends Model {}
 

--- a/server/database/models/ExperimentAttributesValues.ts
+++ b/server/database/models/ExperimentAttributesValues.ts
@@ -1,5 +1,4 @@
 import { DataTypes, Model } from "sequelize"
-import sequelize from "../utils/sequelize"
 
 class ExperimentAttributesValues extends Model {}
 

--- a/server/database/models/ExperimentSection.ts
+++ b/server/database/models/ExperimentSection.ts
@@ -1,5 +1,4 @@
 import { DataTypes, Model } from "sequelize"
-import sequelize from "../utils/sequelize"
 import Section from "./Section"
 
 class ExperimentSection extends Model {}

--- a/server/database/models/Role.ts
+++ b/server/database/models/Role.ts
@@ -1,5 +1,4 @@
 import { DataTypes, Model } from "sequelize"
-import sequelize from "../utils/sequelize"
 
 class Role extends Model {}
 

--- a/server/database/models/Section.ts
+++ b/server/database/models/Section.ts
@@ -1,5 +1,4 @@
 import { DataTypes, Model } from "sequelize"
-import sequelize from "../utils/sequelize"
 
 class Section extends Model {}
 

--- a/server/database/models/User.ts
+++ b/server/database/models/User.ts
@@ -1,6 +1,5 @@
 import bcrypt from "bcrypt"
 import { DataTypes, Model } from "sequelize"
-import sequelize from "../../utils/sequelize"
 
 class User extends Model {}
 


### PR DESCRIPTION
Removes explicit sequelize imports which were anyways wrong in most models since they were moved into the database subfolder. Sequelize should be auto-imported anyways. 