### PR TITLE
Shows toasts on profile page after changes

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -28,10 +28,20 @@
     --accent: 210 40% 96.1%;
     --accent-foreground: 222.2 47.4% 11.2%;
 
+    --success: 143, 85%, 96%;
+    --success-foreground: 140 100% 27%;
+
+    --info: 208, 100%, 97%;
+    --info-foreground: 210, 92%, 45%;
+
+    --warning: 49, 100%, 97%;
+    --warning-foreground: 31, 92%, 45%;
+
+    --error: 359, 100%, 97%;
+    --error-foreground: 360, 100%, 45%;
+
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
-
-    --success: 142.4, 71.8%, 29.2%;
 
     --ring: 222.2 84% 4.9%;
 
@@ -63,10 +73,20 @@
     --accent: 217.2 32.6% 17.5%;
     --accent-foreground: 210 40% 98%;
 
+    --success: 150, 100%, 6%;
+    --success-foreground: 150, 86%, 65%;
+
+    --info: 215, 100%, 6%;
+    --info-foreground: 216, 87%, 65%;
+
+    --warning: 64, 100%, 6%;
+    --warning-foreground: 46, 87%, 65%;
+
+    --error: 358, 76%, 10%;
+    --error-foreground: 358, 100%, 81%;
+
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
-
-    --success: 142.4, 71.8%, 29.2%;
 
     --ring: 212.7 26.8% 83.9%;
   }

--- a/app/components/ui/toast/Toast.vue
+++ b/app/components/ui/toast/Toast.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { ToastRoot, type ToastRootEmits, useForwardPropsEmits } from "radix-vue"
+import { computed } from "vue"
+import { type ToastProps, toastVariants } from "."
+import { cn } from "@/utils/utils"
+
+const props = defineProps<ToastProps>()
+
+const emits = defineEmits<ToastRootEmits>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <ToastRoot
+    v-bind="forwarded"
+    :class="cn(toastVariants({ variant }), props.class)"
+    @update:open="onOpenChange"
+  >
+    <slot />
+  </ToastRoot>
+</template>

--- a/app/components/ui/toast/ToastAction.vue
+++ b/app/components/ui/toast/ToastAction.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { ToastAction, type ToastActionProps } from "radix-vue"
+import { computed, type HTMLAttributes } from "vue"
+import { cn } from "@/utils/utils"
+
+const props = defineProps<ToastActionProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+</script>
+
+<template>
+  <ToastAction
+    v-bind="delegatedProps"
+    :class="cn('inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive', props.class)"
+  >
+    <slot />
+  </ToastAction>
+</template>

--- a/app/components/ui/toast/ToastClose.vue
+++ b/app/components/ui/toast/ToastClose.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { X } from "lucide-vue-next"
+import { ToastClose, type ToastCloseProps } from "radix-vue"
+import { computed, type HTMLAttributes } from "vue"
+import { cn } from "@/utils/utils"
+
+const props = defineProps<ToastCloseProps & {
+  class?: HTMLAttributes["class"]
+}>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+</script>
+
+<template>
+  <ToastClose
+    v-bind="delegatedProps"
+    :class="cn('absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600', props.class)"
+  >
+    <X class="h-4 w-4" />
+  </ToastClose>
+</template>

--- a/app/components/ui/toast/ToastDescription.vue
+++ b/app/components/ui/toast/ToastDescription.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { ToastDescription, type ToastDescriptionProps } from "radix-vue"
+import { computed, type HTMLAttributes } from "vue"
+import { cn } from "@/utils/utils"
+
+const props = defineProps<ToastDescriptionProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+</script>
+
+<template>
+  <ToastDescription
+    :class="cn('text-sm opacity-90', props.class)"
+    v-bind="delegatedProps"
+  >
+    <slot />
+  </ToastDescription>
+</template>

--- a/app/components/ui/toast/ToastProvider.vue
+++ b/app/components/ui/toast/ToastProvider.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { ToastProvider, type ToastProviderProps } from "radix-vue"
+
+const props = defineProps<ToastProviderProps>()
+</script>
+
+<template>
+  <ToastProvider v-bind="props">
+    <slot />
+  </ToastProvider>
+</template>

--- a/app/components/ui/toast/ToastTitle.vue
+++ b/app/components/ui/toast/ToastTitle.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { ToastTitle, type ToastTitleProps } from "radix-vue"
+import { computed, type HTMLAttributes } from "vue"
+import { cn } from "@/utils/utils"
+
+const props = defineProps<ToastTitleProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+</script>
+
+<template>
+  <ToastTitle
+    v-bind="delegatedProps"
+    :class="cn('text-sm font-semibold', props.class)"
+  >
+    <slot />
+  </ToastTitle>
+</template>

--- a/app/components/ui/toast/ToastViewport.vue
+++ b/app/components/ui/toast/ToastViewport.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { ToastViewport, type ToastViewportProps } from "radix-vue"
+import { computed, type HTMLAttributes } from "vue"
+import { cn } from "@/utils/utils"
+
+const props = defineProps<ToastViewportProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+</script>
+
+<template>
+  <ToastViewport
+    v-bind="delegatedProps"
+    :class="cn('fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]', props.class)"
+  />
+</template>

--- a/app/components/ui/toast/Toaster.vue
+++ b/app/components/ui/toast/Toaster.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { isVNode } from "vue"
+import { useToast } from "./use-toast"
+import { Toast, ToastClose, ToastDescription, ToastProvider, ToastTitle, ToastViewport } from "."
+
+const { toasts } = useToast()
+</script>
+
+<template>
+  <ToastProvider>
+    <Toast
+      v-for="toast in toasts"
+      :key="toast.id"
+      v-bind="toast"
+    >
+      <div class="grid gap-1">
+        <ToastTitle v-if="toast.title">
+          {{ toast.title }}
+        </ToastTitle>
+        <template v-if="toast.description">
+          <ToastDescription v-if="isVNode(toast.description)">
+            <component :is="toast.description" />
+          </ToastDescription>
+          <ToastDescription v-else>
+            {{ toast.description }}
+          </ToastDescription>
+        </template>
+        <ToastClose />
+      </div>
+      <component :is="toast.action" />
+    </Toast>
+    <ToastViewport />
+  </ToastProvider>
+</template>

--- a/app/components/ui/toast/index.ts
+++ b/app/components/ui/toast/index.ts
@@ -1,0 +1,47 @@
+import type { ToastRootProps } from "radix-vue"
+import type { HTMLAttributes } from "vue"
+
+import { cva, type VariantProps } from "class-variance-authority"
+
+export { default as Toast } from "./Toast.vue"
+export { default as ToastAction } from "./ToastAction.vue"
+export { default as ToastClose } from "./ToastClose.vue"
+export { default as ToastDescription } from "./ToastDescription.vue"
+export { default as Toaster } from "./Toaster.vue"
+export { default as ToastProvider } from "./ToastProvider.vue"
+export { default as ToastTitle } from "./ToastTitle.vue"
+export { default as ToastViewport } from "./ToastViewport.vue"
+export { toast, useToast } from "./use-toast"
+
+export const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[--radix-toast-swipe-end-x] data-[swipe=move]:translate-x-[--radix-toast-swipe-move-x] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        success:
+          "success group border-success bg-success text-success-foreground",
+        info: "info group border-info bg-info text-info-foreground",
+        warning:
+          "warning group border-warning bg-warning text-warning-foreground",
+        error:
+          "error group border-error bg-error text-error-foreground",
+        destructive:
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
+        // destructive:
+        //             "destructive group border-destructive bg-destructive text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+)
+
+type ToastVariants = VariantProps<typeof toastVariants>
+
+export interface ToastProps extends ToastRootProps {
+  class?: HTMLAttributes["class"]
+  variant?: ToastVariants["variant"]
+  onOpenChange?: ((value: boolean) => void) | undefined
+}

--- a/app/components/ui/toast/use-toast.ts
+++ b/app/components/ui/toast/use-toast.ts
@@ -1,0 +1,164 @@
+import type { Component, VNode } from "vue"
+import { computed, ref } from "vue"
+import type { ToastProps } from "."
+
+const TOAST_LIMIT = 1
+const TOAST_REMOVE_DELAY = 1000000
+
+export type StringOrVNode =
+  | string
+  | VNode
+  | (() => VNode)
+
+type ToasterToast = ToastProps & {
+  id: string
+  title?: string
+  description?: StringOrVNode
+  action?: Component
+}
+
+const actionTypes = {
+  ADD_TOAST: "ADD_TOAST",
+  UPDATE_TOAST: "UPDATE_TOAST",
+  DISMISS_TOAST: "DISMISS_TOAST",
+  REMOVE_TOAST: "REMOVE_TOAST",
+} as const
+
+let count = 0
+
+function genId() {
+  count = (count + 1) % Number.MAX_VALUE
+  return count.toString()
+}
+
+type ActionType = typeof actionTypes
+
+type Action =
+  | {
+    type: ActionType["ADD_TOAST"]
+    toast: ToasterToast
+  }
+  | {
+    type: ActionType["UPDATE_TOAST"]
+    toast: Partial<ToasterToast>
+  }
+  | {
+    type: ActionType["DISMISS_TOAST"]
+    toastId?: ToasterToast["id"]
+  }
+  | {
+    type: ActionType["REMOVE_TOAST"]
+    toastId?: ToasterToast["id"]
+  }
+
+interface State {
+  toasts: ToasterToast[]
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+function addToRemoveQueue(toastId: string) {
+  if (toastTimeouts.has(toastId))
+    return
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId)
+    dispatch({
+      type: actionTypes.REMOVE_TOAST,
+      toastId,
+    })
+  }, TOAST_REMOVE_DELAY)
+
+  toastTimeouts.set(toastId, timeout)
+}
+
+const state = ref<State>({
+  toasts: [],
+})
+
+function dispatch(action: Action) {
+  switch (action.type) {
+    case actionTypes.ADD_TOAST:
+      state.value.toasts = [action.toast, ...state.value.toasts].slice(0, TOAST_LIMIT)
+      break
+
+    case actionTypes.UPDATE_TOAST:
+      state.value.toasts = state.value.toasts.map(t =>
+        t.id === action.toast.id ? { ...t, ...action.toast } : t,
+      )
+      break
+
+    case actionTypes.DISMISS_TOAST: {
+      const { toastId } = action
+
+      if (toastId) {
+        addToRemoveQueue(toastId)
+      } else {
+        state.value.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id)
+        })
+      }
+
+      state.value.toasts = state.value.toasts.map(t =>
+        t.id === toastId || toastId === undefined
+          ? {
+              ...t,
+              open: false,
+            }
+          : t,
+      )
+      break
+    }
+
+    case actionTypes.REMOVE_TOAST:
+      if (action.toastId === undefined)
+        state.value.toasts = []
+      else
+        state.value.toasts = state.value.toasts.filter(t => t.id !== action.toastId)
+
+      break
+  }
+}
+
+function useToast() {
+  return {
+    toasts: computed(() => state.value.toasts),
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: actionTypes.DISMISS_TOAST, toastId }),
+  }
+}
+
+type Toast = Omit<ToasterToast, "id">
+
+function toast(props: Toast) {
+  const id = genId()
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: actionTypes.UPDATE_TOAST,
+      toast: { ...props, id },
+    })
+
+  const dismiss = () => dispatch({ type: actionTypes.DISMISS_TOAST, toastId: id })
+
+  dispatch({
+    type: actionTypes.ADD_TOAST,
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open: boolean) => {
+        if (!open)
+          dismiss()
+      },
+    },
+  })
+
+  return {
+    id,
+    dismiss,
+    update,
+  }
+}
+
+export { toast, useToast }

--- a/app/components/user/UserUpdateAccountDialog.vue
+++ b/app/components/user/UserUpdateAccountDialog.vue
@@ -2,6 +2,7 @@
 import { useForm } from "vee-validate"
 import { toTypedSchema } from "@vee-validate/zod"
 import { z } from "zod"
+import { useToast } from "@/components/ui/toast/use-toast"
 
 const { user } = defineProps({
   user: {
@@ -46,6 +47,7 @@ watch(() => user, (newUser) => {
   }
 })
 
+const { toast } = useToast()
 const onSubmit = form.handleSubmit(async (values) => {
   if (loading.value) return
   loading.value = true
@@ -69,6 +71,14 @@ const onSubmit = form.handleSubmit(async (values) => {
       knownMails.push(values.email)
       form.validate()
     }
+  }
+
+  if (!hasError) {
+    toast({
+      title: "Account aktualisiert",
+      description: "Dein Account wurde erfolgreich aktualisiert.",
+      variant: "success",
+    })
   }
 
   open.value = hasError

--- a/app/components/user/UserUpdatePasswordDialog.vue
+++ b/app/components/user/UserUpdatePasswordDialog.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { useForm } from "vee-validate"
 import { toTypedSchema } from "@vee-validate/zod"
+import { useToast } from "@/components/ui/toast/use-toast"
 
 const loading = ref(false)
 const open = ref(false)
@@ -8,6 +9,7 @@ const open = ref(false)
 const formSchema = toTypedSchema(userUpdatePasswordValidateSchema)
 const form = useForm({ validationSchema: formSchema })
 
+const { toast } = useToast()
 const onSubmit = form.handleSubmit(async (values) => {
   if (loading.value) return
   loading.value = true
@@ -22,6 +24,15 @@ const onSubmit = form.handleSubmit(async (values) => {
   if (error?.code === "INVALID_PASSWORD") {
     hasError = true
     form.setFieldError("oldPassword", "Das Passwort ist falsch")
+  }
+
+  if (!hasError) {
+    toast({
+      title: "Passwort geändert",
+      description: "Dein Passwort wurde erfolgreich geändert.",
+      variant: "success",
+    })
+    open.value = false
   }
 
   open.value = hasError

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import Toaster from "@/components/ui/toast/Toaster.vue"
+</script>
+
 <template>
   <div class="min-h-screen flex flex-col">
     <div class="border-b">
@@ -12,8 +16,6 @@
     </main>
 
     <WebsiteFooter />
+    <Toaster />
   </div>
 </template>
-
-<script setup>
-</script>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -22,7 +22,6 @@ export default <Partial<Config>>{
         ring: "hsl(var(--ring))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
-        success: "hsl(var(--success))",
         primary: {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
@@ -30,6 +29,22 @@ export default <Partial<Config>>{
         secondary: {
           DEFAULT: "hsl(var(--secondary))",
           foreground: "hsl(var(--secondary-foreground))",
+        },
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))",
+        },
+        info: {
+          DEFAULT: "hsl(var(--info))",
+          foreground: "hsl(var(--info-foreground))",
+        },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
+        error: {
+          DEFAULT: "hsl(var(--error))",
+          foreground: "hsl(var(--error-foreground))",
         },
         destructive: {
           DEFAULT: "hsl(var(--destructive))",

--- a/tests/e2e/app/pages/profile.test.ts
+++ b/tests/e2e/app/pages/profile.test.ts
@@ -133,6 +133,13 @@ test.describe("Profile Page", () => {
       - button "Name oder E-Mail ändern"
       - button "Passwort ändern"
       `)
+    // Expect the toast to show
+    await expect(page.getByRole("status", { name: "Account aktualisiert" })).toMatchAriaSnapshot(`
+      - status "Account aktualisiert":
+        - text: Account aktualisiert Dein Account wurde erfolgreich aktualisiert.
+        - button:
+          - img
+      `)
   })
 
   test("change password flow should work", async ({ page }) => {
@@ -239,6 +246,13 @@ test.describe("Profile Page", () => {
     await page.locator("#oldPassword").click()
     await page.locator("#oldPassword").fill("1Password")
     await page.getByRole("button", { name: "Speichern" }).click()
+    // Expect the toast to show
+    await expect(page.getByRole("status", { name: "Passwort geändert" })).toMatchAriaSnapshot(`
+    - status "Passwort geändert":
+      - text: Passwort geändert Dein Passwort wurde erfolgreich geändert.
+      - button:
+        - img
+    `)
   })
 
   test("dialogs should be closable", async ({ page }) => {


### PR DESCRIPTION
Fixes #216 by showing toasts after change profile or password. Also adjusts the tests to reflect these changes. 
Also adds some more colors like info and warning, to extend the toast. But the colors can also be used in other components. 