### PR TITLE
Feature/experiment filter function

### DIFF
--- a/app/components/experiments/Filters.vue
+++ b/app/components/experiments/Filters.vue
@@ -1,8 +1,9 @@
 <script lang="ts" setup>
-const { checked, attributes, showUndoButton } = defineProps<{
+const { checked, attributes, showUndoButton, showAllSelected } = defineProps<{
   checked: string[][]
   attributes: ExperimentAttributeDetail[] | undefined
   showUndoButton: boolean
+  showAllSelected: boolean
 }>()
 
 const emit = defineEmits<{
@@ -17,6 +18,15 @@ function updateModelValueAtIndex(index: number, value: string[]) {
   const newChecked = checked.slice()
   newChecked[index] = value
   updateModelValue(newChecked)
+}
+
+function selectedToString(selected: string[], attribute: ExperimentAttributeDetail) {
+  if (selected.length) {
+    const selectedValues = selected.map(id => attribute.values.find(value => value.id === id)?.value)
+    return showAllSelected ? selectedValues.join(",") : selectedValues.at(0)
+  } else {
+    return "Alle"
+  }
 }
 </script>
 
@@ -40,7 +50,16 @@ function updateModelValueAtIndex(index: number, value: string[]) {
             Keine Optionen gefunden.
           </template>
           <template #preview="{ selected }">
-            {{ selected.length ? selected.map(id => attribute.values.find(value => value.id === id)?.value).join(", ") : "Alle" }}
+            <span style="white-space: nowrap;">
+              {{ selectedToString(selected, attribute) }}
+              <Badge
+                v-if="!showAllSelected && selected.length > 1"
+                class="text-xs"
+                style="background-color: transparent; color: white; border: 1px solid white;"
+              >
+                + {{ selected.length - 1 }}
+              </Badge>
+            </span>
           </template>
           <template #option="{ option }">
             {{ option.value }}

--- a/app/pages/experiments/index.vue
+++ b/app/pages/experiments/index.vue
@@ -31,9 +31,15 @@ initializeFilterChecklist(checked.value)
 
 /* Filter Dialog */
 const dialogOpen = ref(false)
+const temporaryChecked = ref<string[][]>([])
 
+function openDialog() {
+  temporaryChecked.value = checked.value
+  dialogOpen.value = true
+}
 function submitFilters() {
   dialogOpen.value = false
+  checked.value = temporaryChecked.value
 }
 
 /* React to Filter Changes */
@@ -68,7 +74,7 @@ watch(checked, () => {
           <Button
             variant="outline"
             class="flex-grow-8"
-            @click="dialogOpen = true"
+            @click="openDialog"
           >
             Filter <Icon
               name="heroicons:adjustments-horizontal"
@@ -89,6 +95,7 @@ watch(checked, () => {
               :checked="checked"
               :attributes="attributes"
               :show-undo-button="false"
+              @update:checked="temporaryChecked = $event"
             />
             <DialogFooter>
               <Button
@@ -103,6 +110,7 @@ watch(checked, () => {
       </Dialog>
       <ExperimentsUndoFilters
         :checked="checked"
+        @update:checked="checked = $event"
       />
     </div>
 

--- a/app/pages/experiments/index.vue
+++ b/app/pages/experiments/index.vue
@@ -1,7 +1,7 @@
 <script setup lang='ts'>
 const route = useRoute()
 const sort = ref(route.query.sort as string || "none")
-const attributeFilter = ref<string>("")
+const attributeFilter = ref<string>(route.query.attributes as string || "")
 
 const { page, pageSize } = getRequestPageMeta()
 
@@ -23,7 +23,14 @@ function initializeFilterChecklist(list: string[][]) {
   if (!attributes) {
     return
   }
-  attributes.value!.forEach(_ => list.push([]))
+  attributeFilter.value.split(",").forEach((id) => {
+    list.push([])
+    attributes.value?.forEach((attribute, attrIndex) => {
+      if (attribute.values.some(value => value.id === id)) {
+        list[attrIndex]?.push(id)
+      }
+    })
+  })
 }
 
 const checked = ref<string[][]>([])
@@ -49,6 +56,31 @@ watch(checked, () => {
   ).filter(
     attribute => attribute.length > 0,
   ).join(",")
+})
+
+/* Update the URL */
+watch([sort, attributeFilter, page, pageSize], () => {
+  const query:
+  {
+    attributes?: string
+    page?: number
+    pageSize?: number
+    sort?: string
+  } = {}
+  if (attributeFilter.value !== "") {
+    query.attributes = attributeFilter.value
+  }
+  if (page.value !== defaultPage) {
+    query.page = page.value
+  }
+  if (pageSize.value !== defaultPageSize) {
+    query.pageSize = pageSize.value
+  }
+  if (sort.value !== "none") {
+    query.sort = sort.value
+  }
+  const newUrl = { path: route.path, query }
+  useRouter().replace(newUrl)
 })
 </script>
 

--- a/app/pages/experiments/index.vue
+++ b/app/pages/experiments/index.vue
@@ -155,7 +155,7 @@ watch(checked, () => {
 
               <!-- Overlay Content (Defines Section Size) -->
               <div
-                class="relative z-10 p-3 w-full bg-black bg-opacity-50 text-white opacity-50 group-hover:opacity-100 transition-opacity h-full flex items-center justify-center"
+                class="relative z-10 p-3 w-full bg-black bg-opacity-50 text-white opacity-0 group-hover:opacity-100 transition-opacity h-full flex items-center justify-center"
               >
                 <div class="grid grid-cols-2 gap-1">
                   <template

--- a/app/pages/experiments/index.vue
+++ b/app/pages/experiments/index.vue
@@ -23,12 +23,14 @@ function initializeFilterChecklist(list: string[][]) {
   if (!attributes) {
     return
   }
-  attributeFilter.value.split(",").forEach((id) => {
-    list.push([])
+  attributeFilter.value.split(",").forEach((slug) => {
     attributes.value?.forEach((attribute, attrIndex) => {
-      if (attribute.values.some(value => value.id === id)) {
-        list[attrIndex]?.push(id)
-      }
+      list.push([])
+      attribute.values.forEach((value) => {
+        if (value.slug === slug) {
+          list[attrIndex]?.push(value.id)
+        }
+      })
     })
   })
 }

--- a/app/pages/experiments/index.vue
+++ b/app/pages/experiments/index.vue
@@ -106,6 +106,7 @@ watch([sort, attributeFilter, page, pageSize], () => {
         :checked="checked"
         :attributes="attributes"
         :show-undo-button="true"
+        :show-all-selected="false"
         @update:checked="checked = $event"
       />
     </div>
@@ -140,6 +141,7 @@ watch([sort, attributeFilter, page, pageSize], () => {
               :checked="checked"
               :attributes="attributes"
               :show-undo-button="false"
+              :show-all-selected="true"
               @update:checked="temporaryChecked = $event"
             />
             <DialogFooter>

--- a/app/pages/experiments/index.vue
+++ b/app/pages/experiments/index.vue
@@ -1,6 +1,7 @@
 <script setup lang='ts'>
 const route = useRoute()
 const sort = ref(route.query.sort as string || "none")
+const attributeFilter = ref<string>("")
 
 const { page, pageSize } = getRequestPageMeta()
 
@@ -8,6 +9,8 @@ const { data } = useLazyFetch("/api/experiments", {
   query: {
     page: page,
     pageSize: pageSize,
+    sort: sort,
+    attributes: attributeFilter,
   },
 })
 
@@ -32,6 +35,15 @@ const dialogOpen = ref(false)
 function submitFilters() {
   dialogOpen.value = false
 }
+
+/* React to Filter Changes */
+watch(checked, () => {
+  attributeFilter.value = checked.value.map(
+    attribute => attribute.join(","),
+  ).filter(
+    attribute => attribute.length > 0,
+  ).join(",")
+})
 </script>
 
 <template>

--- a/app/pages/experiments/index.vue
+++ b/app/pages/experiments/index.vue
@@ -50,12 +50,25 @@ function submitFilters() {
 }
 
 /* React to Filter Changes */
+function mapFilterIdToSlug(id: string) {
+  for (const attribute of attributes.value || []) {
+    for (const value of attribute.values) {
+      if (id === value.id) {
+        return value.slug
+      }
+    }
+  }
+  return ""
+}
 watch(checked, () => {
   attributeFilter.value = checked.value.map(
-    attribute => attribute.join(","),
+    attribute => attribute.map(
+      attributeValue => mapFilterIdToSlug(attributeValue),
+    ).join(","),
   ).filter(
     attribute => attribute.length > 0,
   ).join(",")
+  console.log(attributeFilter)
 })
 
 /* Update the URL */

--- a/app/utils/pagination.ts
+++ b/app/utils/pagination.ts
@@ -1,10 +1,20 @@
 /**
+ * The default page number to use when no page is specified in the request.
+ */
+export const defaultPage = 1
+
+/**
+ * The default page size to use when no page size is specified in the request.
+ */
+export const defaultPageSize = 12
+
+/**
  * Retrieves the pagination metadata from the current route.
  */
 export function getRequestPageMeta() {
   const route = useRoute()
   return {
-    page: ref(parseInt(route.query.page as string, 10) || 1),
-    pageSize: ref(parseInt(route.query.pageSize as string, 10) || 12),
+    page: ref(parseInt(route.query.page as string, 10) || defaultPage),
+    pageSize: ref(parseInt(route.query.pageSize as string, 10) || defaultPageSize),
   }
 }

--- a/server/api/experiments/index.get.ts
+++ b/server/api/experiments/index.get.ts
@@ -4,10 +4,10 @@ export default defineEventHandler(async (event) => {
   /* Attribute Filter */
   const query = getQuery(event)
   const attributes = (typeof query.attributes === "string" && query.attributes.length > 0) ? query.attributes.split(",") : []
-  const attributeFilters = attributes.map(id => ({
+  const attributeFilters = attributes.map(slug => ({
     attributes: {
       some: {
-        id: id,
+        slug: slug,
       },
     },
   }))


### PR DESCRIPTION
- allows to sort and filter experiments in the experiment overview
- URL is updated with settings -> allows to go back to the page without losing the filter configuration
- fixed a bug that filters cannot be selected in the mobile version
- indicate the number of selected filters for one attribute with a counter (if more than one selected)