### PR TITLE
Improve Experiments

### DIFF
--- a/app/components/TipTapEditor.vue
+++ b/app/components/TipTapEditor.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { Level } from "@tiptap/extension-heading"
+
 const { modelValue } = defineProps({
   modelValue: {
     type: String,
@@ -24,6 +26,12 @@ const editor = useEditor({
 
 const linkUrl = ref("")
 const isLinkDropdownOpen = ref(false)
+
+const headings = [
+  { level: 1, label: "H1" },
+  { level: 2, label: "H2" },
+  { level: 3, label: "H3" },
+] as { level: Level, label: string }[]
 
 function setLinkValue() {
   linkUrl.value = editor.value?.getAttributes("link")?.href || ""
@@ -145,7 +153,20 @@ onBeforeUnmount(() => {
 
           <!-- Headings -->
           <div class="flex gap-1">
-            <Button
+            <template
+              v-for="heading in headings"
+              :key="heading.level"
+            >
+              <Button
+                variant="outline"
+                class="btn aspect-square"
+                :class="{ 'btn-active': editor.isActive('heading', { level: heading.level }) }"
+                @click="editor.chain().focus().toggleHeading({ level: heading.level }).run()"
+              >
+                {{ heading.label }}
+              </Button>
+            </template>
+            <!-- <Button
               variant="outline"
               class="btn aspect-square"
               :class="{ 'btn-active': editor.isActive('heading', { level: 1 }) }"
@@ -168,7 +189,7 @@ onBeforeUnmount(() => {
               @click="editor.chain().focus().toggleHeading({ level: 3 }).run()"
             >
               H3
-            </Button>
+            </Button> -->
           </div>
 
           <!-- Lists -->

--- a/app/pages/experiments/[slug].vue
+++ b/app/pages/experiments/[slug].vue
@@ -92,9 +92,9 @@ const isVideoFile = (mimeType: string) => mimeType.startsWith("video/")
         :key="section.id"
         class="space-y-6"
       >
-        <h3 class="text-xl font-bold">
+        <h2 class="text-3xl font-bold">
           {{ section.experimentSection.name }}
-        </h3>
+        </h2>
         <div
           v-if="section.text && section.text.length && section.text != '<p></p>'"
           class="prose dark:prose-invert"

--- a/app/pages/experiments/edit/[id].vue
+++ b/app/pages/experiments/edit/[id].vue
@@ -450,6 +450,7 @@ async function submitForReview() {
                           placeholder="Beschreibung"
                         />
                       </FormControl>
+                      <FormMessage />
                     </FormItem>
                   </FormField>
                   <div class="m-2">

--- a/app/pages/experiments/edit/[id].vue
+++ b/app/pages/experiments/edit/[id].vue
@@ -143,7 +143,7 @@ async function updateFiles(sectionIndex: number, newFileOrder: ExperimentFileLis
           ...section,
           files: newFileOrder.map(file => ({
             fileId: file.file.id,
-            description: file.description ?? undefined,
+            description: section.files.find(f => f.fileId === file.file.id)?.description,
           })),
         }
       }

--- a/app/pages/experiments/edit/[id].vue
+++ b/app/pages/experiments/edit/[id].vue
@@ -237,6 +237,11 @@ async function submitForReview() {
     variant: "success",
   })
 }
+
+async function previewExperiment() {
+  await onSubmit()
+  navigateTo(`/experiments/${experimentId}`)
+}
 </script>
 
 <template>
@@ -496,7 +501,7 @@ async function submitForReview() {
         <Button
           variant="secondary"
           @click.prevent
-          @click="navigateTo(`/experiments/${experimentId}`)"
+          @click="previewExperiment"
         >
           Vorschau anzeigen
         </Button>

--- a/app/pages/experiments/edit/[id].vue
+++ b/app/pages/experiments/edit/[id].vue
@@ -252,9 +252,9 @@ async function submitForReview() {
         class="grid gap-4 lg:w-2/3"
         @submit="onSubmit"
       >
-        <h3 class="text-xl font-semibold mt-2">
+        <h2 class="text-3xl font-semibold mt-2">
           Allgemeines
-        </h3>
+        </h2>
 
         <FormField
           v-slot="{ componentField }"
@@ -303,9 +303,9 @@ async function submitForReview() {
           </FormItem>
         </FormField>
 
-        <h3 class="text-xl font-semibold mt-2">
+        <h2 class="text-3xl font-semibold mt-2">
           Kategorisierung
-        </h3>
+        </h2>
 
         <template
           v-for="(attribute, index) in attributes"
@@ -375,9 +375,9 @@ async function submitForReview() {
           v-for="section in sections"
           :key="section.id"
         >
-          <h3 class="text-xl font-semibold mt-2">
+          <h2 class="text-3xl font-semibold mt-2">
             {{ section.name }}
-          </h3>
+          </h2>
 
           <FormField
             v-slot="{ componentField }"

--- a/shared/types/Experiment.type.ts
+++ b/shared/types/Experiment.type.ts
@@ -198,7 +198,7 @@ export function getExperimentReadyForReviewSchema(
         .regex(/^(?!<p><\/p>$).*/, "Beschreibung wird benötigt"),
       files: z.array(z.object({
         fileId: z.string().uuid(),
-        description: z.string().optional(),
+        description: z.string({ message: "Beschreibung wird benötigt" }),
       })),
     })).refine((sections) => {
       const sectionIds = sections.map(section => section.experimentSectionContentId)
@@ -210,21 +210,6 @@ export function getExperimentReadyForReviewSchema(
     }, {
       message: "Not enough sections defined",
     }),
-
-    // attributes: z.array(z.object({
-    //   valueId: z.string({ message: "Attribut wird benötigt" }).uuid("Attribut wird benötigt"),
-    // })).refine(async (attributes) => {
-    //   const attributesContained = new Set()
-    //   attributes.forEach((attribute) => {
-    //     if (!attribute.valueId) {
-    //       return
-    //     }
-    //     for (let i = 0; i < attributeValueSets.length; i++) {
-    //       if (attributeValueSets[i]?.has(attribute.valueId)) {
-    //         attributesContained.add(i)
-    //       }
-    //     }
-    //   })
     attributes: z.array(z.object({
       attributeId: z.string().uuid(),
       valueIds: z.array(z.string().uuid()).nonempty("Attribut wird benötigt"),


### PR DESCRIPTION
Requires image description, fixes #316. Keeps the image description after reordering, fixes #310. I would argue this also fixes #282 because the heading handling has been improved. I also explored decreasing the headings but headings are only usable until level 4. Instead I just increased the surrounding headings of the page so the custom content fits in better. 