### PR TITLE
Fix legal edit

### DIFF
--- a/app/pages/legal/[slug].vue
+++ b/app/pages/legal/[slug].vue
@@ -23,6 +23,14 @@ const form = useForm({ validationSchema: formSchema, initialValues: {
 } })
 const openForm = (event: boolean) => {
   open.value = event
+  if (event) {
+    form.resetForm({
+      values: {
+        name: legal.value?.name,
+        text: legal.value?.text,
+      },
+    })
+  }
 }
 
 watch (() => legal.value, (newLegal) => {
@@ -69,7 +77,7 @@ const onSubmit = form.handleSubmit(async (values) => {
             class="m-1 px-5 justify-center"
             @click="open=true"
           >
-            edit
+            Bearbeiten
           </Button>
         </DialogTrigger>
         <DialogContent>

--- a/shared/types/Legal.type.ts
+++ b/shared/types/Legal.type.ts
@@ -30,6 +30,10 @@ export interface LegalDocumentDetail extends LegalDocumentList {
  * Schema for validating updates to a legal document.
  */
 export const legalDocumentUpdateSchema = z.object({
-  name: z.string().trim().nonempty("Please enter a name."),
-  text: z.string().trim().nonempty("Please enter some content."),
+  name: z.string({ message: "Bitte einen Namen eingeben." }).trim().nonempty("Bitte einen Namen eingeben."),
+  text: z.string({ message: "Bitte einen Inhalt eingeben." }).trim().nonempty("Bitte einen Inhalt eingeben."),
+}).refine((value) => {
+  return value.name !== undefined && value.text !== undefined
+}, {
+  message: "Name und Inhalt dürfen nicht leer sein.",
 })

--- a/tests/e2e/app/pages/legal/index.test.ts
+++ b/tests/e2e/app/pages/legal/index.test.ts
@@ -36,7 +36,7 @@ test.describe("Legal Page", () => {
       await page.getByRole("button", { name: "Anmelden" }).click()
       await page.waitForNavigation({ waitUntil: "networkidle" })
       await page.goto(`/legal/${slug}`, { waitUntil: "networkidle" })
-      await page.getByRole("button", { name: "edit" }).click()
+      await page.getByRole("button", { name: "Bearbeiten" }).click()
 
       const newTitle = `updated Legal Document ${uuidv4()}`
       const newContent = `updated Legal for testing purposes ${uuidv4()}`
@@ -60,7 +60,7 @@ test.describe("Legal Page", () => {
       await page.getByRole("button", { name: "Anmelden" }).click()
       await page.waitForNavigation({ waitUntil: "networkidle" })
       await page.goto(`/legal/${slug}`, { waitUntil: "networkidle" })
-      await page.getByRole("button", { name: "edit" }).click()
+      await page.getByRole("button", { name: "Bearbeiten" }).click()
 
       const newTitle = `updated Legal Document ${uuidv4()}`
       const newContent = `updated Legal for testing purposes ${uuidv4()}`
@@ -75,7 +75,7 @@ test.describe("Legal Page", () => {
       await expect(page.getByRole("heading")).toContainText(newTitle)
       await expect(page.getByRole("main")).toContainText(newContent)
 
-      await page.getByRole("button", { name: "edit" }).click()
+      await page.getByRole("button", { name: "Bearbeiten" }).click()
       const newTitle2 = `test2 ${uuidv4()}`
       const newContent2 = `test2 content ${uuidv4()}`
 
@@ -85,6 +85,64 @@ test.describe("Legal Page", () => {
 
       const proseContent3 = page.locator("div[class=\"prose dark:prose-invert\"]")
       await expect(proseContent3).toBeVisible()
+
+      await expect(page.getByRole("heading")).toContainText(newTitle2)
+      await expect(page.getByRole("main")).toContainText(newContent2)
+    })
+    test(`should update the legal documents for Title and Content and updates the legal document with only text/title for ${slug}`, async ({ page }) => {
+      await page.goto("/login", { waitUntil: "networkidle" })
+      // log in as administrator
+      await page.locator("#email").fill("admin@test.test")
+      await page.locator("#password").fill("password")
+      await page.getByRole("button", { name: "Anmelden" }).click()
+      await page.waitForNavigation({ waitUntil: "networkidle" })
+      await page.goto(`/legal/${slug}`, { waitUntil: "networkidle" })
+      await page.getByRole("button", { name: "Bearbeiten" }).click()
+
+      const newTitle = `updated Legal Document ${uuidv4()}`
+      const newContent = `updated Legal for testing purposes ${uuidv4()}`
+
+      await page.locator("#name").fill(newTitle)
+      await page.locator("#text").fill(newContent)
+      await page.getByRole("button", { name: "Speichern" }).click()
+
+      const proseContent2 = page.locator("div[class=\"prose dark:prose-invert\"]")
+      await expect(proseContent2).toBeVisible()
+
+      await expect(page.getByRole("heading")).toContainText(newTitle)
+      await expect(page.getByRole("main")).toContainText(newContent)
+      // only change content
+      await page.getByRole("button", { name: "Bearbeiten" }).click()
+      const newContent2 = `test2 content ${uuidv4()}`
+
+      await page.locator("#text").fill(newContent2)
+      await page.getByRole("button", { name: "Speichern" }).click()
+
+      const proseContent3 = page.locator("div[class=\"prose dark:prose-invert\"]")
+      await expect(proseContent3).toBeVisible()
+
+      await expect(page.getByRole("heading")).toContainText(newTitle)
+      await expect(page.getByRole("main")).toContainText(newContent2)
+
+      // only change Title
+      await page.getByRole("button", { name: "Bearbeiten" }).click()
+      const newTitle2 = `test2 content ${uuidv4()}`
+
+      await page.locator("#name").fill(newTitle2)
+      await page.getByRole("button", { name: "Speichern" }).click()
+
+      const proseContent4 = page.locator("div[class=\"prose dark:prose-invert\"]")
+      await expect(proseContent4).toBeVisible()
+
+      await expect(page.getByRole("heading")).toContainText(newTitle2)
+      await expect(page.getByRole("main")).toContainText(newContent2)
+
+      // no changes at all
+      await page.getByRole("button", { name: "Bearbeiten" }).click()
+      await page.getByRole("button", { name: "Speichern" }).click()
+
+      const proseContent5 = page.locator("div[class=\"prose dark:prose-invert\"]")
+      await expect(proseContent5).toBeVisible()
 
       await expect(page.getByRole("heading")).toContainText(newTitle2)
       await expect(page.getByRole("main")).toContainText(newContent2)

--- a/tests/unit/server/api/legal/[slug].put.test.ts
+++ b/tests/unit/server/api/legal/[slug].put.test.ts
@@ -54,8 +54,8 @@ describe("Api Route PUT /api/legal/{slug}", () => {
   })
 
   it.each([
-    { value: "name", description: "a name" },
-    { value: "text", description: "some content" },
+    { value: "name", description: "einen Namen" },
+    { value: "text", description: "einen Inhalt" },
   ])(`should return an error when the field $value empty`, async ({ value, description }) => {
     const updateContent = {
       name: "New name",
@@ -95,7 +95,7 @@ describe("Api Route PUT /api/legal/{slug}", () => {
 
     await expect(updateLegalDocument(event)).rejects.toThrowError(
       expect.objectContaining({
-        message: expect.stringContaining(`Please enter ${description}`),
+        message: expect.stringContaining(`Bitte ${description} eingeben.`),
       }),
     )
   })


### PR DESCRIPTION
fixes #311
also changed the name of the button from "edit" to "Bearbeiten"
changed the form schema from "required" to "Titel darf nicht leer sein"