### PR TITLE
Add image title display for image files in detail view

### DIFF
--- a/app/components/experiment/Detail.vue
+++ b/app/components/experiment/Detail.vue
@@ -32,9 +32,20 @@ onMounted(() => {
 })
 
 const showDeleteDialog = ref(false)
+const sectionImageStartIndices = computed(() => {
+  if (!experiment?.sections) return []
 
-function getImageTitle(fileIndex: number) {
-  return `Abb. ${fileIndex + 1}`
+  let count = 0
+  return experiment.sections.map((section) => {
+    const startIndex = count
+    count += section.files.length
+    return startIndex
+  })
+})
+
+function getImageTitle(sectionIndex: number, fileIndex: number) {
+  const globalIndex = (sectionImageStartIndices.value[sectionIndex] ?? 0) + fileIndex
+  return `Abb. ${globalIndex + 1}`
 }
 </script>
 
@@ -257,16 +268,16 @@ function getImageTitle(fileIndex: number) {
               </CardContent>
               <Separator class="mb-3" />
               <p
-                  v-if="isImageFile(item.file.mimeType)"
-                  class="w-full whitespace-normal text-center font-semibold pt-2"
+                v-if="isImageFile(item.file.mimeType)"
+                class="w-full whitespace-normal text-center font-semibold pt-2"
               >
-                {{ getImageTitle(index) }}
+                {{ getImageTitle(experiment.sections.indexOf(section), index) }}
               </p>
               <p
                 class="w-full whitespace-normal text-center text-muted-foreground pb-3"
                 style="overflow-wrap: anywhere;"
               >
-               {{ item.description }}
+                {{ item.description }}
               </p>
             </Card>
           </template>

--- a/app/pages/experiments/edit/[id].vue
+++ b/app/pages/experiments/edit/[id].vue
@@ -248,8 +248,20 @@ async function submitForReview() {
   })
 }
 
-function getImageTitle(fileIndex: number) {
-  return `Abb. ${fileIndex + 1}`
+const sectionImageStartIndices = computed(() => {
+  if (!experiment.value?.sections) return []
+
+  let count = 0
+  return experiment.value.sections.map((section) => {
+    const startIndex = count
+    count += section.files?.length ?? 0
+    return startIndex
+  })
+})
+
+function getImageTitle(sectionIndex: number, fileIndex: number) {
+  const globalIndex = (sectionImageStartIndices.value[sectionIndex] ?? 0) + fileIndex
+  return `Abb. ${globalIndex + 1}`
 }
 </script>
 
@@ -464,8 +476,11 @@ function getImageTitle(fileIndex: number) {
                   >
                     <FormItem class="flex-1 p-4 w-full">
                       <FormLabel>
-                        <div v-if="item.file.mimeType.startsWith('image')" class="font-semibold">
-                          {{ getImageTitle(index) }}
+                        <div
+                          v-if="item.file.mimeType.startsWith('image')"
+                          class="font-semibold"
+                        >
+                          {{ getImageTitle(section.order, index) }}
                         </div>
 
                         <NuxtLink


### PR DESCRIPTION
Closes #536 
The system numbers now the pictures after uploading in a section from Abb. 1 to Abb. n that users can refer in the text to the exakt picture.