### PR TITLE
Bugfix/update experiment button

### DIFF
--- a/app/components/experiment/Detail.vue
+++ b/app/components/experiment/Detail.vue
@@ -87,7 +87,7 @@ const showDeleteDialog = ref(false)
             </span>
           </DropdownMenuItem>
           <DropdownMenuItem
-            v-if="user.id === experiment.userId && !experiment.revisedBy"
+            v-if="user.id === experiment.userId && !experiment.revisedBy && (experiment.status === 'IN_REVIEW' || experiment.status === 'PUBLISHED')"
             :disabled="experiment.status === 'IN_REVIEW'"
             :class="{ 'opacity-50': experiment.status === 'IN_REVIEW' }"
             @click="duplicateExperiment(experiment, true)"
@@ -104,6 +104,16 @@ const showDeleteDialog = ref(false)
             <span>
               Zur Überarbeitung
             </span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            v-else-if="user.id === experiment.userId && experiment.status === 'DRAFT' || experiment.status === 'REJECTED'"
+          >
+            <NuxtLink
+              :to="`/experiments/edit/${experiment.id}`"
+              class="no-underline w-full block"
+            >
+              Bearbeiten
+            </NuxtLink>
           </DropdownMenuItem>
           <DropdownMenuItem
             v-if="user !== null && (user.id === experiment.userId || user.role === 'ADMIN')"


### PR DESCRIPTION
Closes #534

Observed two cases: 
1. Experiment is **PUBLISHED** and currently “**IN REVIEW**”→ Clicking **Überarbeiten** does nothing
2. Experiment has been **approved** by admin (review finished) → Clicking **Überarbeiten** correctly navigates to the edit view

The bug is **not functional**, but a UX/state-communication bug. The “Überarbeiten” button is **not broken**. It is conditionally inactive by design, even though the UI still shows it. 

The existing implementation **already prevents users from making edits during the review process**. However, the UI design and the existing “Überarbeiten” button are confusing and ambiguous, as the button is present but does “not function”. To resolve this issue, I have **adjusted the design** and disabled the button during the review process to make the UX more intuitive. 