### PR TITLE
[Bug Fix]: Deleting/Banning users

### DIFF
--- a/app/components/AdminUserTable/actions.vue
+++ b/app/components/AdminUserTable/actions.vue
@@ -22,31 +22,63 @@ async function handleImpersonate() {
   })
 }
 async function handleBan() {
-  await useAuth().client.admin.banUser({ userId: user.id })
-  emit("changed", { banned: true })
-  toast({
-    title: "Account gesperrt",
-    description: `${user.name}'s Account wurde erfolgreich gesperrt.`,
-    variant: "success",
-  })
+  try {
+    await $fetch(`/api/users/${user.id}/ban`, { method: "POST" })
+
+    emit("changed", { banned: true })
+
+    toast({
+      title: "Account gesperrt",
+      description: `${user.name}'s Account wurde erfolgreich gesperrt.`,
+      variant: "success",
+    })
+  } catch {
+    toast({
+      title: "Fehler beim Sperren",
+      description: "Der Account konnte nicht gesperrt werden.",
+      variant: "destructive",
+    })
+  }
 }
 async function handleUnban() {
-  await useAuth().client.admin.unbanUser({ userId: user.id })
-  emit("changed", { banned: false })
-  toast({
-    title: "Accountsperre aufgehoben",
-    description: `${user.name}'s Accountsperre wurde erfolgreich aufgehoben.`,
-    variant: "success",
-  })
+  try {
+    await $fetch(`/api/users/${user.id}/unban`, { method: "POST" })
+
+    emit("changed", { banned: false })
+
+    toast({
+      title: "Accountsperre aufgehoben",
+      description: `${user.name}'s Accountsperre wurde erfolgreich aufgehoben.`,
+      variant: "success",
+    })
+  } catch {
+    toast({
+      title: "Fehler beim Aufheben der Sperre",
+      description: "Die Accountsperre konnte nicht aufgehoben werden.",
+      variant: "destructive",
+    })
+  }
 }
 async function handleDelete() {
-  await useAuth().client.admin.removeUser({ userId: user.id })
-  emit("deleted")
-  toast({
-    title: "Account gelöscht",
-    description: `${user.name}'s Account wurde erfolgreich gelöscht.`,
-    variant: "success",
-  })
+  try {
+    await $fetch(`/api/users/${user.id}/delete`, {
+      method: "POST",
+    })
+
+    emit("deleted")
+
+    toast({
+      title: "Account gelöscht",
+      description: `${user.name}'s Account wurde erfolgreich gelöscht.`,
+      variant: "success",
+    })
+  } catch {
+    toast({
+      title: "Fehler beim Löschen",
+      description: "Der Accound konnte nicht gelöscht werden.",
+      variant: "destructive",
+    })
+  }
 }
 </script>
 
@@ -94,17 +126,9 @@ async function handleDelete() {
         message="Diese Aktion kann nicht rückgängig gemacht werden. Der Account wird dauerhaft gelöscht."
         :on-delete="handleDelete"
       >
-        <Tooltip>
-          <TooltipTrigger>
-            <Icon
-              class="mx-1 h-4 w-4"
-              name="heroicons:trash"
-            />
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Löschen</p>
-          </TooltipContent>
-        </Tooltip>
+        <button type="button" class="mx-1">
+          <Icon class="h-4 w-4 text-destructive" name="heroicons:trash" />
+        </button>
       </ConfirmDeleteAlertDialog>
     </TooltipProvider>
   </div>

--- a/server/api/users/[id]/ban.post.ts
+++ b/server/api/users/[id]/ban.post.ts
@@ -1,0 +1,41 @@
+import { authorize } from "~~/server/utils/authorization"
+import { userAbilities } from "~~/shared/utils/abilities"
+import { getIdPrismaWhereClause } from "~~/server/utils/prisma"
+
+/**
+ * POST /api/users/:id/ban
+ *
+ * Secure backend endpont for banning a user
+ *
+ * Bans a user by setting `banned = true`
+ * Executed with admin privileges
+ */
+export default defineEventHandler(async (event) => {
+  // Admins only
+  await authorize(event, userAbilities.put)
+
+  const where = getIdPrismaWhereClause(event)
+
+  const target = await prisma.user.findUnique({ where })
+  if (!target) {
+    throw createError({ status: 404, message: "User not found" })
+  }
+
+  // Guard: already banned
+  if (target.banned) {
+    return {
+      id: target.id,
+      banned: true,
+    }
+  }
+
+  const updated = await prisma.user.update({
+    where,
+    data: { banned: true },
+  })
+
+  return {
+    id: updated.id,
+    banned: true,
+  }
+})

--- a/server/api/users/[id]/delete.ts
+++ b/server/api/users/[id]/delete.ts
@@ -1,0 +1,45 @@
+import { authorize } from "~~/server/utils/authorization"
+import { userAbilities } from "~~/shared/utils/abilities"
+import { getIdPrismaWhereClause } from "~~/server/utils/prisma"
+
+/**
+ * DELTE /api/users/:id
+ *
+ * Secure backend endpoint for deleting a user
+ *
+ * Authozation is enforced sever-side and executed with admin rights
+ */
+export default defineEventHandler(async (event) => {
+  // Admins only
+  await authorize(event, userAbilities.delete)
+
+  const where = getIdPrismaWhereClause(event)
+
+  // Load target user
+  const target = await prisma.user.findUnique({ where })
+  if (!target) {
+    throw createError({ status: 404, message: "User not found" })
+  }
+
+  // Guard: prevent deleting the last remaining admin
+  if (target.role === "ADMIN") {
+    const adminCount = await prisma.user.count({
+      where: { role: "ADMIN" },
+    })
+
+    if (adminCount === 1) {
+      throw createError({
+        status: 400,
+        message: "Cannot delete the last admin user",
+      })
+    }
+  }
+
+  // Perform deletion
+  await prisma.user.delete({ where })
+
+  return {
+    id: target.id,
+    deleted: true,
+  }
+})

--- a/server/api/users/[id]/unban.post.ts
+++ b/server/api/users/[id]/unban.post.ts
@@ -1,0 +1,38 @@
+import { authorize } from "~~/server/utils/authorization"
+import { userAbilities } from "~~/shared/utils/abilities"
+import { getIdPrismaWhereClause } from "~~/server/utils/prisma"
+
+/**
+ * POST /api/users/:id/unban
+ *
+ * Lifts a user's ban by setting `banned = false`
+ */
+export default defineEventHandler(async (event) => {
+  // Admins only
+  await authorize(event, userAbilities.put)
+
+  const where = getIdPrismaWhereClause(event)
+
+  const target = await prisma.user.findUnique({ where })
+  if (!target) {
+    throw createError({ status: 404, message: "User not found" })
+  }
+
+  // Guard: already unbanned
+  if (!target.banned) {
+    return {
+      id: target.id,
+      banned: false,
+    }
+  }
+
+  const updated = await prisma.user.update({
+    where,
+    data: { banned: false },
+  })
+
+  return {
+    id: updated.id,
+    banned: false,
+  }
+})

--- a/tests/unit/server/api/users/[id]/ban.post.test.ts
+++ b/tests/unit/server/api/users/[id]/ban.post.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, expectTypeOf, vi } from "vitest"
+import { detail } from "../data"
+import endpoint from "~~/server/api/users/[id]/ban.post"
+import { users } from "~~/tests/helpers/auth"
+import * as u from "~~/tests/helpers/utils"
+import type { EndpointResult } from "~~/tests/helpers/utils"
+
+describe("Api Route POST /api/users/{id}/ban", () => {
+  const data = { ...detail, banned: false }
+
+  const expected = {
+    id: data.id,
+    banned: true,
+  }
+
+  const context = u.getTestContext({
+    endpoint,
+    params: { id: data.id },
+    user: users.admin,
+    data,
+    expected,
+  })
+
+  u.mockPrismaForIdPut(context, "user")
+
+  {
+    // Type-level contract
+    expectTypeOf<EndpointResult<typeof endpoint>>().toEqualTypeOf<typeof expected>()
+
+    // Success path
+    u.testSuccess(context)
+
+    // Invalid / missing ID
+    u.testIdFails(context)
+
+    // Authorization: only admins can ban users
+    u.testAuthFail(context, [users.guest, users.user, users.mod])
+
+    it("is a no-op if user is already banned", async () => {
+      prisma.user.findUnique = vi.fn().mockResolvedValue({
+        ...data,
+        banned: true,
+      })
+
+      const result = await endpoint(u.getEvent(context))
+
+      expect(result).toEqual({
+        id: data.id,
+        banned: true,
+      })
+    })
+
+    it("returns 404 if user does not exist", async () => {
+      prisma.user.findUnique = vi.fn().mockResolvedValue(null)
+
+      await expect(endpoint(u.getEvent(context))).rejects.toThrow("User not found")
+    })
+  }
+})

--- a/tests/unit/server/api/users/[id]/delete.test.ts
+++ b/tests/unit/server/api/users/[id]/delete.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, expectTypeOf, vi } from "vitest"
+import { detail } from "../data"
+import endpoint from "~~/server/api/users/[id]/delete"
+import { users } from "~~/tests/helpers/auth"
+import * as u from "~~/tests/helpers/utils"
+import type { EndpointResult } from "~~/tests/helpers/utils"
+
+describe("Api Route DELETE /api/users/{id}", () => {
+  const data = detail
+
+  const expected = {
+    id: data.id,
+    deleted: true,
+  }
+
+  const context = u.getTestContext({
+    endpoint,
+    params: { id: data.id },
+    user: users.admin,
+    data,
+    expected,
+  })
+
+  // Mocking Prismas delete-by-id behavior
+  u.mockPrismaForIdDelete(context, "user")
+
+  {
+    // Ensuring endpoint returns the expected shape
+    expectTypeOf<EndpointResult<typeof endpoint>>().toEqualTypeOf<typeof expected>()
+
+    // Success path: admin deletes a user
+    u.testSuccess(context)
+
+    // Invalid / missing ID
+    u.testIdFails(context)
+
+    // Authorization: only admins can delete users
+    u.testAuthFail(context, [users.guest, users.user, users.mod])
+
+    it("prevents deleting the last admin", async () => {
+      prisma.user.findUnique = vi.fn().mockResolvedValue({
+        ...data,
+        role: "ADMIN",
+      })
+
+      prisma.user.count = vi.fn().mockResolvedValueOnce(1)
+
+      await expect(endpoint(u.getEvent(context))).rejects.toThrow(
+        "Cannot delete the last admin user",
+      )
+    })
+
+    it("returns 404 if user does not exist", async () => {
+      prisma.user.findUnique = vi.fn().mockResolvedValue(null)
+
+      await expect(endpoint(u.getEvent(context))).rejects.toThrow("User not found")
+    })
+  }
+})

--- a/tests/unit/server/api/users/[id]/unban.post.test.ts
+++ b/tests/unit/server/api/users/[id]/unban.post.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, expectTypeOf, vi } from "vitest"
+import { detail } from "../data"
+import endpoint from "~~/server/api/users/[id]/unban.post"
+import { users } from "~~/tests/helpers/auth"
+import * as u from "~~/tests/helpers/utils"
+import type { EndpointResult } from "~~/tests/helpers/utils"
+
+describe("Api Route POST /api/users/{id}/unban", () => {
+  const data = { ...detail, banned: true }
+
+  const expected = {
+    id: data.id,
+    banned: false,
+  }
+
+  const context = u.getTestContext({
+    endpoint,
+    params: { id: data.id },
+    user: users.admin,
+    data,
+    expected,
+  })
+
+  u.mockPrismaForIdPut(context, "user")
+
+  {
+    // Type-level contract
+    expectTypeOf<EndpointResult<typeof endpoint>>().toEqualTypeOf<typeof expected>()
+
+    // Success path
+    u.testSuccess(context)
+
+    // Invalid / missing ID
+    u.testIdFails(context)
+
+    // Authorization: only admins can unban users
+    u.testAuthFail(context, [users.guest, users.user, users.mod])
+
+    it("is a no-op if user is not banned", async () => {
+      prisma.user.findUnique = vi.fn().mockResolvedValue({
+        ...data,
+        banned: false,
+      })
+
+      const result = await endpoint(u.getEvent(context))
+
+      expect(result).toEqual({
+        id: data.id,
+        banned: false,
+      })
+    })
+
+    it("returns 404 if user does not exist", async () => {
+      prisma.user.findUnique = vi.fn().mockResolvedValue(null)
+
+      await expect(endpoint(u.getEvent(context))).rejects.toThrow("User not found")
+    })
+  }
+})


### PR DESCRIPTION
**Fixes #556**

Solution follows the approach in #562.

- Added new server API endpoints:
/api/users/[id]/delete, /api/users/[id]/ban, /api/users/[id]/unban
- Frontend now calls these endpoints via $fetch instead of useAuth().client.admin.*
- Success and error toasts are displayed for all actions
- Added comprehensive unit tests for delete, ban, and unban