### PR TITLE
[FIX] Restrict avatar interaction based on view permissions

### DIFF
--- a/app/components/AuthControl.vue
+++ b/app/components/AuthControl.vue
@@ -21,7 +21,7 @@ async function signOut() {
 <template>
   <DropdownMenu v-if="user">
     <DropdownMenuTrigger as-child>
-      <Avatar>
+      <Avatar react>
         <AvatarFallback>{{ getInitials(user.name) }}</AvatarFallback>
       </Avatar>
     </DropdownMenuTrigger>

--- a/app/components/experiment/comment/Detail.vue
+++ b/app/components/experiment/comment/Detail.vue
@@ -47,7 +47,11 @@ const canSeeMenu = computed(
       <CardContent class="flex justify-between flex-col sm:flex-row p-4 gap-4">
         <div class="flex flex-col space-y-2 flex-grow">
           <div class="flex flex-row items-center space-x-2">
-            <Avatar class="w-8 h-8">
+            <Avatar
+              class="w-8 h-8"
+              :react="canViewUser"
+              @click="canViewUser ? navigateTo(`/users?search=${comment.user.id}`) : null"
+            >
               <AvatarFallback class="text-xs">
                 {{ getInitials(comment.user.name) }}
               </AvatarFallback>

--- a/app/components/ui/avatar/Avatar.vue
+++ b/app/components/ui/avatar/Avatar.vue
@@ -8,14 +8,23 @@ const props = withDefaults(defineProps<{
   class?: HTMLAttributes["class"]
   size?: AvatarVariants["size"]
   shape?: AvatarVariants["shape"]
+  react?: boolean
 }>(), {
   size: "sm",
   shape: "circle",
+  react: false,
 })
 </script>
 
 <template>
-  <AvatarRoot :class="cn(avatarVariant({ size, shape }), props.class)">
+  <AvatarRoot
+    :class="cn(avatarVariant({
+      size: props.size,
+      shape: props.shape,
+      react: props.react,
+    }), props.class)"
+    v-bind="$attrs"
+  >
     <slot />
   </AvatarRoot>
 </template>

--- a/app/components/ui/avatar/index.ts
+++ b/app/components/ui/avatar/index.ts
@@ -5,7 +5,7 @@ export { default as AvatarFallback } from "./AvatarFallback.vue"
 export { default as AvatarImage } from "./AvatarImage.vue"
 
 export const avatarVariant = cva(
-  "inline-flex items-center justify-center font-normal text-foreground select-none shrink-0 bg-secondary overflow-hidden transition-colors ring-1 ring-transparent hover:ring-primary/30 hover:bg-secondary/80 cursor-pointer",
+  "inline-flex items-center justify-center font-normal text-foreground select-none shrink-0 bg-secondary overflow-hidden transition-colors ring-1 ring-transparent",
   {
     variants: {
       size: {
@@ -17,6 +17,15 @@ export const avatarVariant = cva(
         circle: "rounded-full",
         square: "rounded-md",
       },
+      react: {
+        true: "hover:ring-primary/30 hover:bg-secondary/80 cursor-pointer",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      size: "sm",
+      shape: "circle",
+      react: false,
     },
   },
 )

--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -224,7 +224,10 @@ function getErrorMessage(e: unknown, fallback = "Ungültiger Code"): string {
     <Card>
       <CardContent class="p-6">
         <div class="flex items-center flex-col sm:flex-row">
-          <Avatar class="w-24 h-24 mb-4 sm:mb-0 sm:mr-4 mx-auto">
+          <Avatar
+            react
+            class="w-24 h-24 mb-4 sm:mb-0 sm:mr-4 mx-auto"
+          >
             <AvatarFallback class="text-xl font-bold">
               {{ getInitials(user.name) }}
             </AvatarFallback>


### PR DESCRIPTION
This PR fixes a bug where the Avatar component ignored the `canViewUser` permission state, allowing users to think they can trigger something.
Caused by #549
Closes #594

## Changes
- Added `react` prop binding tto toggle CVA variants
  - Fixed with the react prop that normal Users cant see visually a hover effect or click icon
- Added the `@click` handler to check the permission state and go to the user page
