### PR TITLE
perf: singleton auth client to prevent repeated instantiation

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -4,14 +4,12 @@ import { createAuthClient } from "better-auth/vue"
 /**
  * Auth client instance configured with plugins.
  */
+const client = createAuthClient({
+  plugins: [adminClient()],
+  baseURL: useRequestURL().origin,
+})
+
 export const useAuth = () => {
-  const url = useRequestURL()
-  const client = createAuthClient({
-    plugins: [adminClient()],
-    baseURL: url.origin,
-  })
-
   const session = client.useSession(useFetch)
-
   return { session, client }
 }


### PR DESCRIPTION
Moves `createAuthClient` outside of `useAuth` so the client is created once and reused across all calls instead of being reinstantiated on every invocation.

**Problem**
The auth client was being recreated on every `useAuth()` call, causing a new stateless instance each time. Leading to session state not being available immediately and unnecessary overhead.

**Changes**
- Extract `createAuthClient` into a module-level singleton
- `useAuth` now returns the shared instance instead of creating a new one