### PR TITLE
Limit description length for image description

### DIFF
--- a/app/pages/experiments/edit/[id].vue
+++ b/app/pages/experiments/edit/[id].vue
@@ -510,35 +510,41 @@ function getImageTitle(sectionIndex: number, fileIndex: number) {
                 />
                 <div class="flex flex-col flex-1 md:flex-row items-center">
                   <FormField
-                    v-slot="{ componentField }"
+                    v-slot="{ componentField, value }"
                     :name="`sections[${section.order}].files[${index}].description`"
                   >
                     <FormItem class="flex-1 p-4 w-full">
-                      <FormLabel>
-                        <div
-                          v-if="item.file.mimeType.startsWith('image')"
-                          class="font-semibold"
-                        >
-                          {{ getImageTitle(section.order, index) }}
+                      <FormLabel class="flex justify-between items-end">
+                        <div>
+                          <div
+                            v-if="item.file.mimeType.startsWith('image')"
+                            class="font-semibold"
+                          >
+                            {{ getImageTitle(section.order, index) }}
+                          </div>
+                          <NuxtLink
+                            :to="item.file.path"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="hover:underline"
+                            external
+                          >
+                            {{ item.file.originalName }}
+                            <Icon name="heroicons:arrow-top-right-on-square" />
+                          </NuxtLink>
                         </div>
-
-                        <NuxtLink
-                          :to="item.file.path"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          class="hover:underline"
-                          external
+                        <span
+                          :class="['text-[10px] font-medium transition-colors text-muted-foreground']"
                         >
-                          {{ item.file.originalName }}
-                          <Icon name="heroicons:arrow-top-right-on-square" />
-                        </NuxtLink>
+                          {{ value?.length || 0 }} / 1000
+                        </span>
                       </FormLabel>
                       <FormControl>
                         <Textarea
                           v-bind="componentField"
-                          type="text"
-                          placeholder="Beschreibung"
-                          class="resize-y min-h-[80px] max-h-[350px] overflow-auto"
+                          placeholder="Beschreibung (max. 1.000 Zeichen)"
+                          class="resize-y min-h-[80px] max-h-[350px] "
+                          :maxlength="1000"
                         />
                       </FormControl>
                       <FormMessage />

--- a/shared/types/Experiment.type.ts
+++ b/shared/types/Experiment.type.ts
@@ -124,7 +124,7 @@ export function getExperimentSchema(
       text: z.string(),
       files: z.array(z.object({
         fileId: z.string().uuid(),
-        description: z.string().optional(),
+        description: z.string().max(1000, "Die Beschreibung darf maximal 1000 Zeichen lang sein.").optional(),
       })),
     })).refine((sections) => {
       const sectionIds = sections.map(section => section.experimentSectionContentId)


### PR DESCRIPTION
Closes #610
Limit description length to 1000 characters. Otherwise it could be blown up too much
Should we show the letter count only when exceeding 80%?