### PR TITLE
feat: client-side auth check for favoriting

### DIFF
--- a/app/components/experiment/favorites/FavoriteButton.vue
+++ b/app/components/experiment/favorites/FavoriteButton.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { toast } from "~/components/ui/toast"
+
 const props = defineProps<{
   experimentId: string
   isFavoritedInitial: boolean
@@ -10,12 +12,26 @@ syncFavoriteState(props.experimentId, props.isFavoritedInitial)
 
 const isFavorited = computed(() => favoriteState.value[props.experimentId] ?? props.isFavoritedInitial)
 const isLoading = ref(false)
+const canRate = await allows(experimentAbilities.rate)
 
 async function handleToggle() {
+  if (!canRate.value) {
+    toast({
+      title: "Anmeldung erforderlich",
+      description: "Bitte logge dich ein, um Favoriten zu speichern.",
+      variant: "destructive",
+    })
+    return navigateTo("/login")
+  }
+
   if (isLoading.value) return
   isLoading.value = true
-  await toggleFavorite(props.experimentId)
-  isLoading.value = false
+
+  try {
+    await toggleFavorite(props.experimentId)
+  } finally {
+    isLoading.value = false
+  }
 }
 </script>
 

--- a/app/composables/useFavorite.ts
+++ b/app/composables/useFavorite.ts
@@ -13,11 +13,10 @@ export const useFavorite = () => {
 
       favoriteState.value[experimentId] = favorited
       return favorited
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Aktion fehlgeschlagen"
+    } catch {
       toast({
         title: "Fehler",
-        description: message,
+        description: "Aktion fehlgeschlagen",
         variant: "destructive",
       })
       return null


### PR DESCRIPTION
Prevents unauthenticated users from triggering a "401 Not logged in" error when clicking the favorite button.
Closes #612

## Changes
- Redirects guests to `/login` 
- Throws explanatory toast
- Suppressed technical 401 error toasts in `useFavorite.ts`


Before: <img width="367" height="120" alt="image" src="https://github.com/user-attachments/assets/d8831163-4e96-4e49-ad26-207d65b66fc7" />
Now: <img width="371" height="100" alt="image" src="https://github.com/user-attachments/assets/7321d469-962a-48d7-bfa6-30a05399792c" />
