### PR TITLE
fix: remove second "My Favorites" button from AuthControl

### DIFF
--- a/app/components/AuthControl.vue
+++ b/app/components/AuthControl.vue
@@ -89,12 +89,6 @@ const dropdownOpen = ref(false)
         </DropdownMenuItem>
       </NuxtLink>
 
-      <NuxtLink href="/experiments/favorites">
-        <DropdownMenuItem as-child>
-          <span>Meine Favoriten</span>
-        </DropdownMenuItem>
-      </NuxtLink>
-
       <DropdownMenuSeparator v-if="canSeeUsers || canReviewExperiments" />
 
       <NuxtLink href="/users">


### PR DESCRIPTION
Self explaining. Caused due to merge conflict
<img width="156" height="217" alt="image" src="https://github.com/user-attachments/assets/24b9542b-e035-4fc1-8c9b-7d068c2b5192" />
