### PR TITLE
fix: resolve type mismatch in ExperimentAttributeValueDetail

### DIFF
--- a/server/utils/experiment.ts
+++ b/server/utils/experiment.ts
@@ -21,6 +21,7 @@ export const experimentIncludeForToList = {
       id: true,
       slug: true,
       value: true,
+      order: true,
       attribute: {
         select: {
           id: true,
@@ -77,6 +78,12 @@ export const experimentIncludeForToDetail = {
           order: true,
         },
       },
+    },
+  },
+  reviews: {
+    select: {
+      reviewerId: true,
+      updatedAt: true,
     },
   },
 }


### PR DESCRIPTION
This also ensures that the ExperimentIncorrectList and ExperimentIncorrectDetail interfaces are correctly populated, preventing AssertionError during unit tests where strictly equal objects are expected.