### PR TITLE
fix: prevent freeze for old experiments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM --platform=$BUILDPLATFORM node:23-alpine AS build
+FROM node:23-alpine AS build
 
 # Update and install the latest dependencies for the alpine version
 RUN apk update && apk upgrade && apk add openssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM node:23-alpine AS build
+FROM --platform=$BUILDPLATFORM node:23-alpine AS build
 
 # Update and install the latest dependencies for the alpine version
 RUN apk update && apk upgrade && apk add openssl

--- a/app/components/DraggableList.vue
+++ b/app/components/DraggableList.vue
@@ -16,24 +16,24 @@ const emit = defineEmits<{
   (e: "update:values", value: T[]): void
 }>()
 
-const [parent, items] = useDragAndDrop(values, { group: group })
+const [parent, items] = useDragAndDrop([...values], {
+  group: group,
+  // Watch for changes in the `items` array and emit an event when the order changes
+  onSort: () => {
+    nextTick(() => emit("update:values", [...items.value]))
+  },
+})
 
 // Watch for changes in the `values` prop and update `items`
 watch(
-  () => values,
-  (newValues) => {
-    items.value = [...newValues] // Sync `items` with the prop values
+  () => values.map(v => v.id).join(","),
+  (newIds) => {
+    const currentIds = items.value.map(i => i.id).join(",")
+    if (currentIds !== newIds) {
+      items.value = [...values]
+    }
   },
-  { deep: true, immediate: true },
-)
-
-// Watch for changes in the `items` array and emit an event when the order changes
-watch(
-  items,
-  (newItems) => {
-    emit("update:values", [...newItems]) // Notify the parent of the updated order
-  },
-  { deep: true },
+  { immediate: true },
 )
 </script>
 

--- a/app/components/DraggableList.vue
+++ b/app/components/DraggableList.vue
@@ -18,7 +18,7 @@ const emit = defineEmits<{
 
 const [parent, items] = useDragAndDrop([...values], {
   group: group,
-  // Watch for changes in the `items` array and emit an event when the order changes
+  // Triggers when the user reorders elements; emits the new state to the parent component
   onSort: () => {
     nextTick(() => emit("update:values", [...items.value]))
   },

--- a/app/pages/experiments/edit/[id].vue
+++ b/app/pages/experiments/edit/[id].vue
@@ -51,6 +51,20 @@ const latestReview = computed(() => {
   )[0]
 })
 
+const critiquesMap = computed(() => {
+  const map: Record<string, any[]> = {}
+
+  latestReview.value?.sectionsCritiques?.forEach(critique => {
+    const id = critique.sectionContent?.experimentSection?.id
+    if (id) {
+      if (!map[id]) map[id] = []
+      map[id].push(critique)
+    }
+  })
+
+  return map
+})
+
 function isRiskAssessmentSection(sectionName: string | undefined) {
   return sectionName === "Gefährdungsbeurteilung"
 }
@@ -81,7 +95,7 @@ const form = useForm({
         experimentSectionContentId: experimentSection?.id,
         experimentSectionId: section.id,
         files: (experimentSection?.files ?? []).map(file => ({
-          fileId: file.file?.id ?? "",
+          fileId: file.file?.id,
           description: file.description ?? undefined,
         })),
       }
@@ -636,33 +650,22 @@ const { openReports, dismissReport, startRevision } = useExperimentReports(exper
             </template>
           </DraggableList>
           <!-- Critiques für diese Section -->
-          <div
-            v-if="latestReview"
-            class="mt-6"
-          >
-            <div
-              v-if="latestReview.sectionsCritiques.some(c => c.sectionContent?.experimentSection?.id === section.id)"
-              class="space-y-2"
-            >
-              <h3 class="font-semibold text-sm flex items-center gap-2">
-                <Icon
-                  name="heroicons:user-circle"
-                  class="w-4 h-4"
-                />
-                Aktuelles Feedback
-              </h3>
+          <div v-if="critiquesMap[section.id]" class="mt-6 space-y-2">
+            <h3 class="font-semibold text-sm flex items-center gap-2">
+              <Icon name="heroicons:user-circle" class="w-4 h-4" />
+              Aktuelles Feedback
+            </h3>
 
-              <div
-                v-for="critique in latestReview.sectionsCritiques.filter(c => c.sectionContent?.experimentSection?.id === section.id)"
+            <div
+                v-for="critique in critiquesMap[section.id]" :key="critique.id">
                 :key="critique.id"
                 class="border rounded-lg p-4 bg-destructive/5 border-destructive/20 shadow-sm"
-              >
-                <p class="text-[10px] font-bold uppercase tracking-wider text-destructive mb-2">
-                  Korrekturhinweis
-                </p>
-                <div class="prose prose-sm dark:prose-invert">
-                  <LatexContent :content="critique.critique" />
-                </div>
+            >
+              <p class="text-[10px] font-bold uppercase tracking-wider text-destructive mb-2">
+                Korrekturhinweis
+              </p>
+              <div class="prose prose-sm dark:prose-invert">
+                <LatexContent :content="critique.critique" />
               </div>
             </div>
           </div>

--- a/app/pages/experiments/edit/[id].vue
+++ b/app/pages/experiments/edit/[id].vue
@@ -26,9 +26,7 @@ if (!user.value) {
 }
 
 const emailVerified = user.value?.emailVerified
-
 const loading = ref(false)
-
 const experimentId = getId()
 const { data: experiment } = await useFetch<ExperimentDetail>(`/api/experiments/${experimentId}`)
 
@@ -42,6 +40,10 @@ if (experiment.value?.status !== "DRAFT" && experiment.value?.status !== "REJECT
 const { data: sections } = await useFetch("/api/experiments/sections")
 const { data: attributes } = await useFetch("/api/experiments/attributes")
 const { data: availableSigns } = await useFetch<Sign[]>("/api/signs")
+const { data: reviews } = await useFetch(
+  `/api/experiments/review/by-experiment?experimentId=${experimentId}`,
+)
+
 const latestReview = computed(() => {
   if (!reviews.value?.length) return null
   return [...reviews.value].sort((a, b) =>
@@ -77,20 +79,19 @@ const form = useForm({
       return {
         text: experimentSection?.text ?? "",
         experimentSectionContentId: experimentSection?.id,
-        files: experimentSection?.files.map(file => ({
-          fileId: file.file.id,
+        experimentSectionId: section.id,
+        files: (experimentSection?.files ?? []).map(file => ({
+          fileId: file.file?.id ?? "",
           description: file.description ?? undefined,
-        })) ?? [],
+        })),
       }
     }) ?? [],
-    signs: experiment.value?.signs.map(s => ({ id: s.id })) ?? [],
+    signs: (experiment.value?.signs ?? []).map(s => ({ id: s.id })),
   },
 })
 
 let formValuesClone = JSON.stringify(form.values)
-const formChanged = toRef(() => {
-  return formValuesClone !== JSON.stringify(form.values)
-})
+const formChanged = computed(() => formValuesClone !== JSON.stringify(form.values))
 
 let interval: string | number | NodeJS.Timeout | null | undefined = null
 
@@ -158,10 +159,6 @@ async function uploadPreviewImage(newFiles: [File]) {
     deleteFiles([oldFileId])
   }
 }
-
-const { data: reviews } = await useFetch(
-  `/api/experiments/review/by-experiment?experimentId=${experimentId}`,
-)
 
 async function uploadSectionFile(sectionIndex: number, newFiles: File[]) {
   const sectionName = sections.value?.[sectionIndex]?.name
@@ -255,22 +252,26 @@ async function saveForm(values: typeof form.values) {
 }
 
 const onSubmit = form.handleSubmit(async (values) => {
-  if (!user.value) return
-  if (!emailVerified) return
-  if (loading.value) return
+  if (!user.value || !emailVerified || loading.value) return
   loading.value = true
 
-  const response = await saveForm(values)
-  experiment.value = response
-  formValuesClone = JSON.stringify(form.values)
-
-  loading.value = false
-
-  toast({
-    title: "Versuch gespeichert",
-    description: "Der Versuch wurde erfolgreich gespeichert.",
-    variant: "success",
-  })
+  try {
+    experiment.value = await saveForm(values)
+    formValuesClone = JSON.stringify(form.values)
+    toast({
+      title: "Versuch gespeichert",
+      description: "Der Versuch wurde erfolgreich gespeichert.",
+      variant: "success",
+    })
+  } catch {
+    toast({
+      title: "Fehler beim Speichern",
+      description: "Der Versuch konnte nicht gespeichert werden.",
+      variant: "error",
+    })
+  } finally {
+    loading.value = false
+  }
 })
 
 async function submitForReview() {
@@ -320,8 +321,17 @@ const sectionImageStartIndices = computed(() => {
 })
 
 function getImageTitle(sectionIndex: number, fileIndex: number) {
+  if (!sectionImageStartIndices.value || sectionImageStartIndices.value.length <= sectionIndex) {
+    return `Abb. ?`
+  }
   const globalIndex = (sectionImageStartIndices.value[sectionIndex] ?? 0) + fileIndex
   return `Abb. ${globalIndex + 1}`
+}
+
+function getFilesForSection(sectionId: string) {
+  if (!experiment.value?.sections) return []
+  const sectionContent = experiment.value.sections.find(s => s.experimentSection.id === sectionId)
+  return sectionContent?.files ?? []
 }
 
 const { openReports, dismissReport, startRevision } = useExperimentReports(experiment)
@@ -500,7 +510,7 @@ const { openReports, dismissReport, startRevision } = useExperimentReports(exper
         </FormField>
 
         <template
-          v-for="section in sections"
+          v-for="(section, index) in sections"
           :key="section.id"
         >
           <h2 class="text-3xl font-semibold mt-2">
@@ -516,13 +526,13 @@ const { openReports, dismissReport, startRevision } = useExperimentReports(exper
           <FormField
             v-if="!isRiskAssessmentSection(section.name)"
             v-slot="{ componentField }"
-            :name="`sections[${section.order}].text`"
+            :name="`sections[${index}].text`"
           >
             <FormItem>
               <FormLabel>Beschreibung</FormLabel>
               <FormControl>
                 <TipTapEditor
-                  :id="`sections[${section.order}].text`"
+                  :id="`sections[${index}].text`"
                   v-bind="componentField"
                   :show-headings="false"
                   @click.prevent
@@ -540,13 +550,13 @@ const { openReports, dismissReport, startRevision } = useExperimentReports(exper
               : 'Ziehe Dateien hierher oder klicke, um Dateien hochzuladen.'"
             icon="heroicons:cloud-arrow-up"
             :accept="isRiskAssessmentSection(section.name) ? ['application/pdf'] : sectionFileAccepts"
-            @dropped="event => uploadSectionFile(section.order, event)"
+            @dropped="event => uploadSectionFile(index, event)"
           />
           <DraggableList
-            :values="experiment?.sections[section.order]?.files ?? []"
-            @update:values="newFileOrder => updateFiles(section.order, newFileOrder)"
+            :values="getFilesForSection(section.id)"
+            @update:values="newFileOrder => updateFiles(index, newFileOrder)"
           >
-            <template #item="{ item, index }">
+            <template #item="{ item, index: fileIndex }">
               <Card
                 class="flex items-center"
               >
@@ -566,7 +576,7 @@ const { openReports, dismissReport, startRevision } = useExperimentReports(exper
                 <div class="flex flex-col flex-1 md:flex-row items-center">
                   <FormField
                     v-slot="{ componentField, value }"
-                    :name="`sections[${section.order}].files[${index}].description`"
+                    :name="`sections[${index}].files[${fileIndex}].description`"
                   >
                     <FormItem class="flex-1 p-4 w-full">
                       <FormLabel class="flex justify-between items-end">
@@ -575,7 +585,7 @@ const { openReports, dismissReport, startRevision } = useExperimentReports(exper
                             v-if="item.file.mimeType.startsWith('image')"
                             class="font-semibold"
                           >
-                            {{ getImageTitle(section.order, index) }}
+                            {{ getImageTitle(index, fileIndex) }}
                           </div>
                           <NuxtLink
                             :to="item.file.path"
@@ -613,7 +623,7 @@ const { openReports, dismissReport, startRevision } = useExperimentReports(exper
 
                     <Button
                       variant="ghost"
-                      @click="removeFile(section.order, item.file.id)"
+                      @click="removeFile(index, item.file.id)"
                     >
                       <Icon
                         name="heroicons:trash"
@@ -631,7 +641,7 @@ const { openReports, dismissReport, startRevision } = useExperimentReports(exper
             class="mt-6"
           >
             <div
-              v-if="latestReview.sectionsCritiques.some(c => c.sectionContent.experimentSection.id === section.id)"
+              v-if="latestReview.sectionsCritiques.some(c => c.sectionContent?.experimentSection?.id === section.id)"
               class="space-y-2"
             >
               <h3 class="font-semibold text-sm flex items-center gap-2">
@@ -643,7 +653,7 @@ const { openReports, dismissReport, startRevision } = useExperimentReports(exper
               </h3>
 
               <div
-                v-for="critique in latestReview.sectionsCritiques.filter(c => c.sectionContent.experimentSection.id === section.id)"
+                v-for="critique in latestReview.sectionsCritiques.filter(c => c.sectionContent?.experimentSection?.id === section.id)"
                 :key="critique.id"
                 class="border rounded-lg p-4 bg-destructive/5 border-destructive/20 shadow-sm"
               >

--- a/shared/types/Experiment.type.ts
+++ b/shared/types/Experiment.type.ts
@@ -163,6 +163,7 @@ export function getExperimentSchema(
 
     sections: z.array(z.object({
       experimentSectionContentId: z.string().uuid().optional(),
+      experimentSectionId: z.string().uuid(),
       text: z.string(),
       files: z.array(z.object({
         fileId: z.string().uuid(),


### PR DESCRIPTION
This PR fixes a critical performance issue where the experiment editor would freeze due to an infinite reactivity loop between the DraggableList and the form state. It also improves the robustness of the editor when handling legacy experiments with missing or non-sequential sections.

## Changes
### Stabilization of Drag & Drop Logic
- The DraggableList now uses the onSort hook instead of a deep watcher. Updates are only fired when the actual order of files changes, not on description text edits
- The component now checks via an ID string if the list has structurally changed before overwriting the internal state

### Robust Section Management
- The template now consistently uses the loop index. This ensures the form array and the UI remain in sync, regardless of the order ID stored in the database
- Introduced the getFilesForSection(sectionId) helper function, which safely extracts files by ID from the state instead of relying on risky array indices

### UI & Performance
- Section loops now use a fixed section.id as the :key to prevent unnecessary re-mounting of the TipTap editor during typing
- getImageTitle was secured to provide correct figure numbers (or placeholders) even during asynchronous loading states

## Impact
- Eliminated page freezes during auto-save or file reordering
- Restored compatibility with legacy experiments that have a different section structure
- Smoother typing in the editor as re-render cycles have been minimized