### PR TITLE
chore: upgrade base image to Node.js 24-alpine (LTS)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "23"
+          node-version: "24"
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "23"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "23"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM node:23-alpine AS build
+FROM node:24-alpine AS build
 
 # Update and install the latest dependencies for the alpine version
 RUN apk update && apk upgrade && apk add openssl
@@ -23,7 +23,7 @@ RUN npm run build
 # ================================
 # Run image
 # ================================
-FROM node:23-alpine AS run
+FROM node:24-alpine AS run
 
 # Update and install latest dependencies
 RUN apk update && apk upgrade && apk add ffmpeg && adduser -D nuxtuser


### PR DESCRIPTION
This PR updates the Dockerfile base image from node:23-alpine to node:24-alpine.

## Changes
- **LTS Upgrade**: Moves from Node 23 (interim release) to Node 24 (Long Term Support) for better security and stability

## Why
- Node.js 23 is officially deprecated. Node 23 reached EOL in June 2025.
- Security Risk: As a "Current" release, it only received 8 months of support. It has not received security patches, OpenSSL updates, or V8 engine fixes for approximately 9 months