### PR TITLE
chore: upgrade GitHub Actions to support Node.js 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,16 +23,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           registry: ${{ env.REGISTRY }}
@@ -41,7 +41,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
           flavor: |
@@ -60,7 +60,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           context: .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "23"
           cache: 'npm'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "23"
           cache: "npm"
@@ -63,7 +63,7 @@ jobs:
         run: npm run test:e2e
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "23"
           cache: "npm"


### PR DESCRIPTION
## Summary
This PR updates several GitHub Actions to their latest versions to ensure compatibility with **Node.js 24**. GitHub has announced the deprecation of Node.js 20 runners, and actions will be forced to run on Node.js 24 starting June 2026.

## Changes
Updated the following actions in `build.yml`, `test.yml`, `lint.yml` and `playwright.yml`:
- `actions/checkout` from `v4` to `v6`
- `actions/setup-node` from `v4` to `v6`
- `actions/upload-artifact` from `v4` to `v6`
- `docker/setup-qemu-action` from `v3` to `v4`
- `docker/setup-buildx-action` from `v3` to `v4`
- `docker/login-action` from `v3` to `v4`
- `docker/metadata-action` from `v5` to `v6`
- `docker/build-push-action` from `v6` to `v7`

## Why
To avoid workflow warnings and potential failures related to the Node.js 20 deprecation on GitHub Actions runners.

Ref: [GitHub Changelog - Deprecation of Node 20 on GitHub Actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)