### PR TITLE
fix: create missing sections on clone

### DIFF
--- a/server/api/experiments/[slug].put.ts
+++ b/server/api/experiments/[slug].put.ts
@@ -66,6 +66,26 @@ export default defineEventHandler(async (event) => {
               },
             },
           })),
+        create: sanitizedExperimentData.sections
+          .map((section, index) => ({ section, globalSectionId: sections[index].id }))
+          .filter(({ section }) => !section.experimentSectionContentId)
+          .map(({ section, globalSectionId }) => ({
+            text: section.text,
+            experimentSection: {
+              connect: { id: globalSectionId },
+            },
+            files: {
+              create: (section.files || [])
+                .filter(file => !!file.fileId)
+                .map((file, index) => ({
+                  description: file.description,
+                  order: index,
+                  file: {
+                    connect: { id: file.fileId },
+                  },
+                })),
+            },
+          })),
       },
       attributes: {
         set: [],


### PR DESCRIPTION
### Description
This PR fixes an issue where users were unable to submit cloned or older experiments for review. 

Previously, when an older experiment was edited or cloned, it sometimes lacked newly added database sections (e.g., Risk Assessment). The frontend displayed these as empty fields, but the `PUT` endpoint (`/api/experiments/[slug].put.ts`) only updated existing sections and ignored sections missing an `experimentSectionContentId`. As a result, the missing sections were never created in the database, causing the Zod review schema validation to fail with a generic "Not all required fields are filled out" error.

### Changes
- Updated `server/api/experiments/[slug].put.ts` to include a `create` block within the `sections` update transaction
- The backend now maps the index of the submitted sections to the global section IDs and explicitly creates any section that does not yet have an `experimentSectionContentId`
